### PR TITLE
Add builds key to manifests

### DIFF
--- a/libimgui-platform-osx/manifest
+++ b/libimgui-platform-osx/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +macos -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-platform-win32/manifest
+++ b/libimgui-platform-win32/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +windows -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-render-dx10/manifest
+++ b/libimgui-render-dx10/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +windows -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-render-dx11/manifest
+++ b/libimgui-render-dx11/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +windows -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-render-dx12/manifest
+++ b/libimgui-render-dx12/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +windows -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-render-dx9/manifest
+++ b/libimgui-render-dx9/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +windows -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $

--- a/libimgui-render-metal/manifest
+++ b/libimgui-render-metal/manifest
@@ -12,6 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
+builds: &( +macos -gcc )
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $


### PR DESCRIPTION
This PR adds a `builds` keyword to the manifests of the packages to fix `bdep ci` builds as good as possible.

Here's the link to a build with the latest version: https://ci.stage.build2.org/@623ba025-bd7d-4d57-90b0-1fdd0a565a35

@boris-kolpackov quite a few builds are failing because Vulkan or X11 headers are missing. Can you do anything about that? For the linux machines (Debian) you could just install (which is what I did):

* `libvulkan-dev`
* `xorg-dev`

For Windows and MacOS I am not sure. @Klaim  or @Swat-SomeBug any idea what you have to install on those platforms to make Vulkan backends work?