### PR TITLE
Export additional include path

### DIFF
--- a/libimgui-platform-glfw/imgui/backends/imgui_impl_glfw.cpp
+++ b/libimgui-platform-glfw/imgui/backends/imgui_impl_glfw.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_glfw.cpp

--- a/libimgui-platform-glfw/imgui/backends/imgui_impl_glfw.h
+++ b/libimgui-platform-glfw/imgui/backends/imgui_impl_glfw.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_glfw.h

--- a/libimgui-platform-glfw/imgui/buildfile
+++ b/libimgui-platform-glfw/imgui/buildfile
@@ -3,13 +3,14 @@ import intf_libs += glfw%lib{glfw}
 import intf_libs += libimgui%lib{imgui}
 
 lib{imgui-platform-glfw}: {hxx cxx}{**} $intf_libs
+lib{imgui-platform-glfw}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-platform-glfw}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs
 }
 
@@ -23,5 +24,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-platform-glfw/imgui/imgui_impl_glfw.cpp
+++ b/libimgui-platform-glfw/imgui/imgui_impl_glfw.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_glfw.cpp

--- a/libimgui-platform-glfw/imgui/imgui_impl_glfw.h
+++ b/libimgui-platform-glfw/imgui/imgui_impl_glfw.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_glfw.h

--- a/libimgui-platform-osx/imgui/backends/imgui_impl_osx.h
+++ b/libimgui-platform-osx/imgui/backends/imgui_impl_osx.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_osx.h

--- a/libimgui-platform-osx/imgui/backends/imgui_impl_osx.mm
+++ b/libimgui-platform-osx/imgui/backends/imgui_impl_osx.mm
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_osx.mm

--- a/libimgui-platform-osx/imgui/buildfile
+++ b/libimgui-platform-osx/imgui/buildfile
@@ -4,21 +4,22 @@ import intf_libs += libimgui%lib{imgui}
 platform_libs = -framework AppKit -framework ModelIO -framework GameController
 
 lib{imgui-platform-osx}: {hxx cxx}{**} $intf_libs
+lib{imgui-platform-osx}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-platform-osx}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
 define mm: file
 mm{*}: extension = mm
 
-objcxx_files = $name(mm{*})
+objcxx_files = $name(mm{**})
 
 [rule_hint=cxx] libul{imgui-platform-osx-meta}: $intf_libs
 
@@ -35,7 +36,7 @@ obja{~'/(.*).a/'}: mm{~'/\1/'} libua{imgui-platform-osx-meta}
 {{
     dep_poptions = $cxx.lib_poptions(libua{imgui-platform-osx-meta}, obja)
     depdb hash $dep_poptions
-    depdb dyndep "-I$out_root/imgui" "-I$src_root/imgui" \
+    depdb dyndep "-I$out_root/imgui/backends" "-I$src_root/imgui/backends" \
                  --what=header --default-type=h \
                  --update-exclude libua{imgui-platform-osx-meta} \
                  -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
@@ -49,7 +50,7 @@ objs{~'/(.*).so/'}: mm{~'/\1/'} libus{imgui-platform-osx-meta}
 {{
     dep_poptions = $cxx.lib_poptions(libus{imgui-platform-osx-meta}, objs)
     depdb hash $dep_poptions
-    depdb dyndep "-I$out_root/imgui" "-I$src_root/imgui" \
+    depdb dyndep "-I$out_root/imgui/backends" "-I$src_root/imgui/backends" \
                  --what=header --default-type=h \
                  --update-exclude libus{imgui-platform-osx-meta} \
                  -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
@@ -70,5 +71,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-platform-osx/imgui/buildfile
+++ b/libimgui-platform-osx/imgui/buildfile
@@ -19,18 +19,26 @@ lib{imgui-platform-osx}:
 define mm: file
 mm{*}: extension = mm
 
-objcxx_files = $name(mm{**})
+objcxx_files = mm{**}
+obj_dyn =
+obj_stat =
 
 [rule_hint=cxx] libul{imgui-platform-osx-meta}: $intf_libs
 
-for n: $objcxx_files
+for file: $objcxx_files
 {
-    obja{$(n).a.o}: mm{$n}
-    objs{$(n).so.o}: mm{$n}
+    p = "$directory($file)/$name($file)"
+    oa = "$(p).a.o"
+    os = "$(p).so.o"
+    obja{$oa}: $file
+    objs{$os}: $file
+
+    obj_dyn += $os
+    obj_stat += $oa
 }
 
-liba{imgui-platform-osx}: obja{$regex.apply($objcxx_files,'(.+)','\1.a.o')}
-libs{imgui-platform-osx}: objs{$regex.apply($objcxx_files,'(.+)','\1.so.o')}
+liba{imgui-platform-osx}: obja{$obj_stat}
+libs{imgui-platform-osx}: objs{$obj_dyn}
 
 obja{~'/(.*).a/'}: mm{~'/\1/'} libua{imgui-platform-osx-meta}
 {{

--- a/libimgui-platform-osx/imgui/imgui_impl_osx.h
+++ b/libimgui-platform-osx/imgui/imgui_impl_osx.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_osx.h

--- a/libimgui-platform-osx/imgui/imgui_impl_osx.mm
+++ b/libimgui-platform-osx/imgui/imgui_impl_osx.mm
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_osx.mm

--- a/libimgui-platform-win32/imgui/backends/imgui_impl_win32.cpp
+++ b/libimgui-platform-win32/imgui/backends/imgui_impl_win32.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_win32.cpp

--- a/libimgui-platform-win32/imgui/backends/imgui_impl_win32.h
+++ b/libimgui-platform-win32/imgui/backends/imgui_impl_win32.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_win32.h

--- a/libimgui-platform-win32/imgui/buildfile
+++ b/libimgui-platform-win32/imgui/buildfile
@@ -2,13 +2,14 @@ intf_libs = # Interface dependencies.
 import intf_libs += libimgui%lib{imgui}
 
 lib{imgui-platform-win32}: {hxx cxx}{**} $intf_libs
+lib{imgui-platform-win32}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-platform-win32}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs
 }
 
@@ -22,5 +23,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-platform-win32/imgui/imgui_impl_win32.cpp
+++ b/libimgui-platform-win32/imgui/imgui_impl_win32.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_win32.cpp

--- a/libimgui-platform-win32/imgui/imgui_impl_win32.h
+++ b/libimgui-platform-win32/imgui/imgui_impl_win32.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_win32.h

--- a/libimgui-render-dx10/imgui/backends/imgui_impl_dx10.cpp
+++ b/libimgui-render-dx10/imgui/backends/imgui_impl_dx10.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx10.cpp

--- a/libimgui-render-dx10/imgui/backends/imgui_impl_dx10.h
+++ b/libimgui-render-dx10/imgui/backends/imgui_impl_dx10.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx10.h

--- a/libimgui-render-dx10/imgui/buildfile
+++ b/libimgui-render-dx10/imgui/buildfile
@@ -8,14 +8,15 @@ else
 	platform_libs += d3d10.lib d3dcompiler.lib
 
 lib{imgui-render-dx10}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-dx10}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-dx10}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
@@ -29,5 +30,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-dx10/imgui/imgui_impl_dx10.cpp
+++ b/libimgui-render-dx10/imgui/imgui_impl_dx10.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx10.cpp

--- a/libimgui-render-dx10/imgui/imgui_impl_dx10.h
+++ b/libimgui-render-dx10/imgui/imgui_impl_dx10.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx10.h

--- a/libimgui-render-dx11/imgui/backends/imgui_impl_dx11.cpp
+++ b/libimgui-render-dx11/imgui/backends/imgui_impl_dx11.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx11.cpp

--- a/libimgui-render-dx11/imgui/backends/imgui_impl_dx11.h
+++ b/libimgui-render-dx11/imgui/backends/imgui_impl_dx11.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx11.h

--- a/libimgui-render-dx11/imgui/buildfile
+++ b/libimgui-render-dx11/imgui/buildfile
@@ -8,14 +8,15 @@ else
 	platform_libs = d3d11.lib d3dcompiler.lib
 
 lib{imgui-render-dx11}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-dx11}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-dx11}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
@@ -29,5 +30,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-dx11/imgui/imgui_impl_dx11.cpp
+++ b/libimgui-render-dx11/imgui/imgui_impl_dx11.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx11.cpp

--- a/libimgui-render-dx11/imgui/imgui_impl_dx11.h
+++ b/libimgui-render-dx11/imgui/imgui_impl_dx11.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx11.h

--- a/libimgui-render-dx12/imgui/backends/imgui_impl_dx12.cpp
+++ b/libimgui-render-dx12/imgui/backends/imgui_impl_dx12.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx12.cpp

--- a/libimgui-render-dx12/imgui/backends/imgui_impl_dx12.h
+++ b/libimgui-render-dx12/imgui/backends/imgui_impl_dx12.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx12.h

--- a/libimgui-render-dx12/imgui/buildfile
+++ b/libimgui-render-dx12/imgui/buildfile
@@ -8,14 +8,15 @@ else
 	platform_libs = d3d12.lib d3dcompiler.lib dxgi.lib
 
 lib{imgui-render-dx12}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-dx12}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-dx12}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
@@ -29,5 +30,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-dx12/imgui/imgui_impl_dx12.cpp
+++ b/libimgui-render-dx12/imgui/imgui_impl_dx12.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx12.cpp

--- a/libimgui-render-dx12/imgui/imgui_impl_dx12.h
+++ b/libimgui-render-dx12/imgui/imgui_impl_dx12.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx12.h

--- a/libimgui-render-dx9/imgui/backends/imgui_impl_dx9.cpp
+++ b/libimgui-render-dx9/imgui/backends/imgui_impl_dx9.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx9.cpp

--- a/libimgui-render-dx9/imgui/backends/imgui_impl_dx9.h
+++ b/libimgui-render-dx9/imgui/backends/imgui_impl_dx9.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_dx9.h

--- a/libimgui-render-dx9/imgui/buildfile
+++ b/libimgui-render-dx9/imgui/buildfile
@@ -8,14 +8,15 @@ else
 	platform_libs += d3d9.lib
 
 lib{imgui-render-dx9}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-dx9}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-dx9}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
@@ -29,5 +30,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-dx9/imgui/imgui_impl_dx9.cpp
+++ b/libimgui-render-dx9/imgui/imgui_impl_dx9.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx9.cpp

--- a/libimgui-render-dx9/imgui/imgui_impl_dx9.h
+++ b/libimgui-render-dx9/imgui/imgui_impl_dx9.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_dx9.h

--- a/libimgui-render-metal/imgui/backends/imgui_impl_metal.h
+++ b/libimgui-render-metal/imgui/backends/imgui_impl_metal.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_metal.h

--- a/libimgui-render-metal/imgui/backends/imgui_impl_metal.mm
+++ b/libimgui-render-metal/imgui/backends/imgui_impl_metal.mm
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_metal.mm

--- a/libimgui-render-metal/imgui/buildfile
+++ b/libimgui-render-metal/imgui/buildfile
@@ -20,18 +20,26 @@ lib{imgui-render-metal}:
 define mm: file
 mm{*}: extension = mm
 
-objcxx_files = $name(mm{**})
+objcxx_files = mm{**}
+obj_dyn =
+obj_stat =
 
 [rule_hint=cxx] libul{imgui-render-metal-meta}: $intf_libs
 
-for n: $objcxx_files
+for file: $objcxx_files
 {
-    obja{$(n).a.o}: mm{$n}
-    objs{$(n).so.o}: mm{$n}
+    p = "$directory($file)/$name($file)"
+    oa = "$(p).a.o"
+    os = "$(p).so.o"
+    obja{$oa}: $file
+    objs{$os}: $file
+
+    obj_dyn += $os
+    obj_stat += $oa
 }
 
-liba{imgui-render-metal}: obja{$regex.apply($objcxx_files,'(.+)','\1.a.o')}
-libs{imgui-render-metal}: objs{$regex.apply($objcxx_files,'(.+)','\1.so.o')}
+liba{imgui-render-metal}: obja{$obj_stat}
+libs{imgui-render-metal}: objs{$obj_dyn}
 
 obja{~'/(.*).a/'}: mm{~'/\1/'} libua{imgui-render-metal-meta}
 {{

--- a/libimgui-render-metal/imgui/buildfile
+++ b/libimgui-render-metal/imgui/buildfile
@@ -5,21 +5,22 @@ platform_libs = -framework AppKit -framework ModelIO -framework Metal -framework
 platform_coptions = -fobjc-weak
 
 lib{imgui-render-metal}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-metal}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
 cxx.libs += $platform_libs
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-metal}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs $platform_libs
 }
 
 define mm: file
 mm{*}: extension = mm
 
-objcxx_files = $name(mm{*})
+objcxx_files = $name(mm{**})
 
 [rule_hint=cxx] libul{imgui-render-metal-meta}: $intf_libs
 
@@ -36,7 +37,7 @@ obja{~'/(.*).a/'}: mm{~'/\1/'} libua{imgui-render-metal-meta}
 {{
     dep_poptions = $cxx.lib_poptions(libua{imgui-render-metal-meta}, obja)
     depdb hash $dep_poptions
-    depdb dyndep "-I$out_root/imgui" "-I$src_root/imgui" \
+    depdb dyndep "-I$out_root/imgui/backends" "-I$src_root/imgui/backends" \
                  --what=header --default-type=h \
                  --update-exclude libua{imgui-render-metal-meta} \
                  -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
@@ -50,7 +51,7 @@ objs{~'/(.*).so/'}: mm{~'/\1/'} libus{imgui-render-metal-meta}
 {{
     dep_poptions = $cxx.lib_poptions(libus{imgui-render-metal-meta}, objs)
     depdb hash $dep_poptions
-    depdb dyndep "-I$out_root/imgui" "-I$src_root/imgui" \
+    depdb dyndep "-I$out_root/imgui/backends" "-I$src_root/imgui/backends" \
                  --what=header --default-type=h \
                  --update-exclude libus{imgui-render-metal-meta} \
                  -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
@@ -71,5 +72,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-metal/imgui/imgui_impl_metal.h
+++ b/libimgui-render-metal/imgui/imgui_impl_metal.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_metal.h

--- a/libimgui-render-metal/imgui/imgui_impl_metal.mm
+++ b/libimgui-render-metal/imgui/imgui_impl_metal.mm
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_metal.mm

--- a/libimgui-render-opengl2/imgui/backends/imgui_impl_opengl2.cpp
+++ b/libimgui-render-opengl2/imgui/backends/imgui_impl_opengl2.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_opengl2.cpp

--- a/libimgui-render-opengl2/imgui/backends/imgui_impl_opengl2.h
+++ b/libimgui-render-opengl2/imgui/backends/imgui_impl_opengl2.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_opengl2.h

--- a/libimgui-render-opengl2/imgui/buildfile
+++ b/libimgui-render-opengl2/imgui/buildfile
@@ -3,13 +3,14 @@ import intf_libs += libopengl-meta%lib{opengl-gl}
 import intf_libs += libimgui%lib{imgui}
 
 lib{imgui-render-opengl2}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-opengl2}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-opengl2}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs
 }
 
@@ -23,5 +24,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-opengl2/imgui/imgui_impl_opengl2.cpp
+++ b/libimgui-render-opengl2/imgui/imgui_impl_opengl2.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_opengl2.cpp

--- a/libimgui-render-opengl2/imgui/imgui_impl_opengl2.h
+++ b/libimgui-render-opengl2/imgui/imgui_impl_opengl2.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_opengl2.h

--- a/libimgui-render-opengl2/manifest
+++ b/libimgui-render-opengl2/manifest
@@ -15,4 +15,4 @@ package-email: swat.somebug@gmail.com
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $
-depends: libopengl-meta
+depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3.cpp
+++ b/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_opengl3.cpp

--- a/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3.h
+++ b/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_opengl3.h

--- a/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3_loader.h
+++ b/libimgui-render-opengl3/imgui/backends/imgui_impl_opengl3_loader.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_opengl3_loader.h

--- a/libimgui-render-opengl3/imgui/buildfile
+++ b/libimgui-render-opengl3/imgui/buildfile
@@ -3,13 +3,14 @@ import intf_libs += libopengl-meta%lib{opengl-gl}
 import intf_libs += libimgui%lib{imgui}
 
 lib{imgui-render-opengl3}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-opengl3}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-opengl3}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs
 }
 
@@ -23,5 +24,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-opengl3/imgui/imgui_impl_opengl3.cpp
+++ b/libimgui-render-opengl3/imgui/imgui_impl_opengl3.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_opengl3.cpp

--- a/libimgui-render-opengl3/imgui/imgui_impl_opengl3.h
+++ b/libimgui-render-opengl3/imgui/imgui_impl_opengl3.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_opengl3.h

--- a/libimgui-render-opengl3/imgui/imgui_impl_opengl3_loader.h
+++ b/libimgui-render-opengl3/imgui/imgui_impl_opengl3_loader.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_opengl3_loader.h

--- a/libimgui-render-opengl3/manifest
+++ b/libimgui-render-opengl3/manifest
@@ -15,4 +15,4 @@ package-email: swat.somebug@gmail.com
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $
-depends: libopengl-meta
+depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-vulkan/imgui/backends/imgui_impl_vulkan.cpp
+++ b/libimgui-render-vulkan/imgui/backends/imgui_impl_vulkan.cpp
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_vulkan.cpp

--- a/libimgui-render-vulkan/imgui/backends/imgui_impl_vulkan.h
+++ b/libimgui-render-vulkan/imgui/backends/imgui_impl_vulkan.h
@@ -1,0 +1,1 @@
+../../../upstream/backends/imgui_impl_vulkan.h

--- a/libimgui-render-vulkan/imgui/backends/vulkan
+++ b/libimgui-render-vulkan/imgui/backends/vulkan
@@ -1,0 +1,1 @@
+../../../upstream/backends/vulkan

--- a/libimgui-render-vulkan/imgui/backends/vulkan
+++ b/libimgui-render-vulkan/imgui/backends/vulkan
@@ -1,1 +1,0 @@
-../../../upstream/backends/vulkan

--- a/libimgui-render-vulkan/imgui/buildfile
+++ b/libimgui-render-vulkan/imgui/buildfile
@@ -3,13 +3,14 @@ import intf_libs += libimgui%lib{imgui}
 import intf_libs += libvulkan-meta%lib{vulkan}
 
 lib{imgui-render-vulkan}: {hxx cxx}{**} $intf_libs
+lib{imgui-render-vulkan}: cxx.pkgconfig.include = include/ include/imgui/backends/
 
-cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_IMPL_EXPORT
+cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 
 # Export options.
 lib{imgui-render-vulkan}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base/backends" "-I$src_base/backends" "-I$out_root" "-I$src_root"
     cxx.export.libs = $intf_libs
 }
 
@@ -23,5 +24,6 @@ else
 
 hxx{*}:
 {
-    install = include/imgui/backends/
+    install = include/imgui/
+    install.subdirs = true
 }

--- a/libimgui-render-vulkan/imgui/imgui_impl_vulkan.cpp
+++ b/libimgui-render-vulkan/imgui/imgui_impl_vulkan.cpp
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_vulkan.cpp

--- a/libimgui-render-vulkan/imgui/imgui_impl_vulkan.h
+++ b/libimgui-render-vulkan/imgui/imgui_impl_vulkan.h
@@ -1,1 +1,0 @@
-../../upstream/backends/imgui_impl_vulkan.h

--- a/libimgui-render-vulkan/manifest
+++ b/libimgui-render-vulkan/manifest
@@ -15,4 +15,4 @@ package-email: swat.somebug@gmail.com
 depends: * build2 >= 0.15.0-
 depends: * bpkg >= 0.15.0-
 depends: libimgui == $
-depends: libvulkan-meta
+depends: libvulkan-meta ^1.0.0-

--- a/libimgui/imgui/buildfile
+++ b/libimgui/imgui/buildfile
@@ -10,7 +10,7 @@ lib{imgui}:
     cxx.export.poptions = "-I$out_base" "-I$src_base" "-I$out_root" "-I$src_root"
 }
 
-lib{imgui}: cxx.pkgconfig.include = include/ include/imgui/ include/imgui/backends/
+lib{imgui}: cxx.pkgconfig.include = include/ include/imgui/
 
 liba{imgui}: cxx.export.poptions += -DIMGUI_STATIC
 

--- a/libimgui/imgui/buildfile
+++ b/libimgui/imgui/buildfile
@@ -7,10 +7,10 @@ cxx.poptions += "-I$out_base" "-I$src_base" -DIMGUI_EXPORT
 # Export options.
 lib{imgui}:
 {
-    cxx.export.poptions = "-I$out_base" "-I$src_base"
+    cxx.export.poptions = "-I$out_base" "-I$src_base" "-I$out_root" "-I$src_root"
 }
 
-lib{imgui}: cxx.pkgconfig.include = include/imgui/ include/imgui/backends/
+lib{imgui}: cxx.pkgconfig.include = include/ include/imgui/ include/imgui/backends/
 
 liba{imgui}: cxx.export.poptions += -DIMGUI_STATIC
 


### PR DESCRIPTION
This PR adds the ability to also include the headers of the base `imgui` library with a `imgui/` prefix, i.e. the following is possible after this PR:

```cpp
#include <imgui/imgui.h>
```

Basically it is now possible to include the imgui headers with and without the prefix.

I encountered this issue when I ported the `box2d` testbed [here](https://github.com/build2-packaging/box2d) for build2, which includes imgui using this prefix. Also note that box2d includes the backends again *without* prefix, which seems a bit inconsistent.

Open question: should the backends also support being included with a `imgui/backends/` prefix? This would involve moving the sym linked source files in all backend packages into a `imgui/backends/` directory. I decided against this since I have not encountered the use-case yet.
Any opinions?