### PR TITLE
Fix pkgconfig include directory in docking packages

### DIFF
--- a/libimgui-docking/imgui/buildfile
+++ b/libimgui-docking/imgui/buildfile
@@ -26,7 +26,7 @@ lib{imgui-docking}:
     cxx.export.poptions = "-I$out_base" "-I$src_base" "-I$out_root" "-I$src_root" $imconfig_poptions
 }
 
-lib{imgui-docking}: cxx.pkgconfig.include = include/ include/imgui/
+lib{imgui-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/
 
 liba{imgui-docking}: cxx.export.poptions += -DIMGUI_STATIC
 

--- a/libimgui-platform-glfw-docking/imgui/buildfile
+++ b/libimgui-platform-glfw-docking/imgui/buildfile
@@ -3,7 +3,7 @@ import intf_libs += glfw%lib{glfw}
 import intf_libs += libimgui-docking%lib{imgui-docking}
 
 lib{imgui-platform-glfw-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-platform-glfw-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-platform-glfw-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 

--- a/libimgui-platform-osx-docking/imgui/buildfile
+++ b/libimgui-platform-osx-docking/imgui/buildfile
@@ -4,7 +4,7 @@ import intf_libs += libimgui-docking%lib{imgui-docking}
 platform_libs = -framework AppKit -framework ModelIO -framework GameController -framework QuartzCore
 
 lib{imgui-platform-osx-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-platform-osx-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-platform-osx-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-platform-win32-docking/imgui/buildfile
+++ b/libimgui-platform-win32-docking/imgui/buildfile
@@ -2,7 +2,7 @@ intf_libs = # Interface dependencies.
 import intf_libs += libimgui-docking%lib{imgui-docking}
 
 lib{imgui-platform-win32-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-platform-win32-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-platform-win32-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 

--- a/libimgui-render-dx10-docking/imgui/buildfile
+++ b/libimgui-render-dx10-docking/imgui/buildfile
@@ -8,7 +8,7 @@ else
 	platform_libs += d3d10.lib d3dcompiler.lib
 
 lib{imgui-render-dx10-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-dx10-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-dx10-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-render-dx11-docking/imgui/buildfile
+++ b/libimgui-render-dx11-docking/imgui/buildfile
@@ -8,7 +8,7 @@ else
 	platform_libs = d3d11.lib d3dcompiler.lib
 
 lib{imgui-render-dx11-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-dx11-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-dx11-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-render-dx12-docking/imgui/buildfile
+++ b/libimgui-render-dx12-docking/imgui/buildfile
@@ -8,7 +8,7 @@ else
 	platform_libs = d3d12.lib d3dcompiler.lib dxgi.lib
 
 lib{imgui-render-dx12-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-dx12-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-dx12-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-render-dx9-docking/imgui/buildfile
+++ b/libimgui-render-dx9-docking/imgui/buildfile
@@ -8,7 +8,7 @@ else
 	platform_libs += d3d9.lib
 
 lib{imgui-render-dx9-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-dx9-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-dx9-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-render-metal-docking/imgui/buildfile
+++ b/libimgui-render-metal-docking/imgui/buildfile
@@ -5,7 +5,7 @@ platform_libs = -framework AppKit -framework ModelIO -framework Metal -framework
 platform_coptions = -fobjc-weak
 
 lib{imgui-render-metal-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-metal-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-metal-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.libs += $platform_libs
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT

--- a/libimgui-render-opengl2-docking/imgui/buildfile
+++ b/libimgui-render-opengl2-docking/imgui/buildfile
@@ -3,7 +3,7 @@ import intf_libs += libopengl-meta%lib{opengl-gl}
 import intf_libs += libimgui-docking%lib{imgui-docking}
 
 lib{imgui-render-opengl2-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-opengl2-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-opengl2-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 

--- a/libimgui-render-opengl3-docking/imgui/buildfile
+++ b/libimgui-render-opengl3-docking/imgui/buildfile
@@ -3,7 +3,7 @@ import intf_libs += libopengl-meta%lib{opengl-gl}
 import intf_libs += libimgui-docking%lib{imgui-docking}
 
 lib{imgui-render-opengl3-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-opengl3-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-opengl3-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 

--- a/libimgui-render-vulkan-docking/imgui/buildfile
+++ b/libimgui-render-vulkan-docking/imgui/buildfile
@@ -3,7 +3,7 @@ import intf_libs += libimgui-docking%lib{imgui-docking}
 import intf_libs += libvulkan-meta%lib{vulkan}
 
 lib{imgui-render-vulkan-docking}: {hxx cxx}{**} $intf_libs
-lib{imgui-render-vulkan-docking}: cxx.pkgconfig.include = include/ include/imgui/backends/
+lib{imgui-render-vulkan-docking}: cxx.pkgconfig.include = include/ include/imgui-docking/backends/
 
 cxx.poptions += "-I$out_base/backends" "-I$src_base/backends" -DIMGUI_IMPL_EXPORT
 


### PR DESCRIPTION
This was previously pointing to imgui instead of imgui-docking.

https://ci.stage.build2.org/@b87e4189-d589-41b4-a0d7-0cb4699ea2cb?builds=&pv=&th=*&tg=&tc=&pc=&rs=success

Resolve build2-packaging/imgui#24