### PR TITLE
Bump version to 1.91.4

### DIFF
--- a/libimgui-docking/manifest
+++ b/libimgui-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui: Bloat-free Graphical User interface for C++ with minimal dependencies ; docking branch
 license: MIT
@@ -12,8 +12,8 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 
 tests: libimgui-null-backend-test-docking == $
 examples: libimgui-examples-docking == $

--- a/libimgui-examples-docking/manifest
+++ b/libimgui-examples-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-examples-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Executable examples of usage of the Dear ImGui library ; docking branch
 license: MIT
@@ -12,8 +12,8 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-platform-glfw-docking == $
 depends: libimgui-platform-osx-docking == $ ? ($cxx.target.class == 'macos')
 depends: libimgui-platform-win32-docking == $ ? ($cxx.target.class == 'windows')

--- a/libimgui-examples/manifest
+++ b/libimgui-examples/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-examples
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Executable examples of usage of the Dear ImGui library
 license: MIT
@@ -12,8 +12,8 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-platform-glfw == $
 depends: libimgui-platform-osx == $ ? ($cxx.target.class == 'macos')
 depends: libimgui-platform-win32 == $ ? ($cxx.target.class == 'windows')

--- a/libimgui-null-backend-test-docking/manifest
+++ b/libimgui-null-backend-test-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-null-backend-test-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Package using Dear ImGui's example_null backend to test libimgui ; docking branch
 license: MIT
@@ -12,6 +12,6 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 

--- a/libimgui-null-backend-test/manifest
+++ b/libimgui-null-backend-test/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-null-backend-test
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Package using Dear ImGui's example_null backend to test libimgui.
 license: MIT
@@ -12,6 +12,6 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 

--- a/libimgui-platform-glfw-docking/manifest
+++ b/libimgui-platform-glfw-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-glfw-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for GLFW ; docking branch
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $
 depends: glfw ^3.3.4

--- a/libimgui-platform-glfw/manifest
+++ b/libimgui-platform-glfw/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-glfw
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for GLFW
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $
 depends: glfw ^3.3.4

--- a/libimgui-platform-osx-docking/manifest
+++ b/libimgui-platform-osx-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-osx-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for OSX ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +macos -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-platform-osx/manifest
+++ b/libimgui-platform-osx/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-osx
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for OSX
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +macos -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-platform-win32-docking/manifest
+++ b/libimgui-platform-win32-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-win32-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for Win32 ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-platform-win32/manifest
+++ b/libimgui-platform-win32/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-platform-win32
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui platform backend for Win32
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-dx10-docking/manifest
+++ b/libimgui-render-dx10-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx10-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 10 ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-render-dx10/manifest
+++ b/libimgui-render-dx10/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx10
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 10
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-dx11-docking/manifest
+++ b/libimgui-render-dx11-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx11-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 11 ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-render-dx11/manifest
+++ b/libimgui-render-dx11/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx11
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 11
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-dx12-docking/manifest
+++ b/libimgui-render-dx12-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx12-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 12 ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-render-dx12/manifest
+++ b/libimgui-render-dx12/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx12
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 12
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-dx9-docking/manifest
+++ b/libimgui-render-dx9-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx9-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 9 ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-render-dx9/manifest
+++ b/libimgui-render-dx9/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-dx9
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for DirectX 9
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +windows -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-metal-docking/manifest
+++ b/libimgui-render-metal-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-metal-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Metal ; docking branch
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +macos -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $

--- a/libimgui-render-metal/manifest
+++ b/libimgui-render-metal/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-metal
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Metal
 license: MIT
@@ -13,6 +13,6 @@ package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
 builds: &( +macos -gcc )
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $

--- a/libimgui-render-opengl2-docking/manifest
+++ b/libimgui-render-opengl2-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-opengl2-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Open GL 2 ; docking branch
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $
 depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-opengl2/manifest
+++ b/libimgui-render-opengl2/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-opengl2
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Open GL 2
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $
 depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-opengl3-docking/manifest
+++ b/libimgui-render-opengl3-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-opengl3-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for OpenGL 3 ; docking branch
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $
 depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-opengl3/manifest
+++ b/libimgui-render-opengl3/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-opengl3
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for OpenGL 3
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $
 depends: libopengl-meta ^1.0.0-

--- a/libimgui-render-vulkan-docking/manifest
+++ b/libimgui-render-vulkan-docking/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-vulkan-docking
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Vulkan ; docking branch
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui-docking == $
 depends: libvulkan-meta ^1.0.0

--- a/libimgui-render-vulkan/manifest
+++ b/libimgui-render-vulkan/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui-render-vulkan
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui render backend for Vulkan
 license: MIT
@@ -12,7 +12,7 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 depends: libimgui == $
 depends: libvulkan-meta ^1.0.0

--- a/libimgui/imgui/imconfig.h
+++ b/libimgui/imgui/imconfig.h
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// COMPILE-TIME OPTIONS FOR DEAR IMGUI
+// DEAR IMGUI COMPILE-TIME OPTIONS
 // Runtime options (clipboard callbacks, enabling various features, etc.) can generally be set via the ImGuiIO structure.
 // You can use ImGui::SetAllocatorFunctions() before calling ImGui::CreateContext() to rewire memory allocation functions.
 //-----------------------------------------------------------------------------
@@ -9,7 +9,7 @@
 // You need to make sure that configuration settings are defined consistently _everywhere_ Dear ImGui is used, which include the imgui*.cpp
 // files but also _any_ of your code that uses Dear ImGui. This is because some compile-time options have an affect on data structures.
 // Defining those options in imconfig.h will ensure every compilation unit gets to see the same data structure layouts.
-// Call IMGUI_CHECKVERSION() from your .cpp files to verify that the data structures your files are using are matching the ones imgui.cpp is using.
+// Call IMGUI_CHECKVERSION() from your .cpp file to verify that the data structures your files are using are matching the ones imgui.cpp is using.
 //-----------------------------------------------------------------------------
 
 #pragma once
@@ -21,8 +21,9 @@
 
 //---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
 // Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
-// DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
-// for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
+// - Windows DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
+//   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
+
 #ifdef _WIN32
 #ifndef IMGUI_STATIC
 
@@ -41,21 +42,23 @@
 #endif
 #endif
 
-//---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to avoid using soon-to-be obsolete function/names.
+//---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to clean your code of obsolete function/names.
 //#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+//#define IMGUI_DISABLE_OBSOLETE_KEYIO                      // 1.87+ disable legacy io.KeyMap[]+io.KeysDown[] in favor io.AddKeyEvent(). This is automatically done by IMGUI_DISABLE_OBSOLETE_FUNCTIONS.
 
-//---- Disable all of Dear ImGui or don't implement standard windows.
-// It is very strongly recommended to NOT disable the demo windows during development. Please read comments in imgui_demo.cpp.
+//---- Disable all of Dear ImGui or don't implement standard windows/tools.
+// It is very strongly recommended to NOT disable the demo windows and debug tool during development. They are extremely useful in day to day work. Please read comments in imgui_demo.cpp.
 //#define IMGUI_DISABLE                                     // Disable everything: all headers and source files will be empty.
-//#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty. Not recommended.
-//#define IMGUI_DISABLE_METRICS_WINDOW                      // Disable metrics/debugger and other debug tools: ShowMetricsWindow() and ShowStackToolWindow() will be empty.
+//#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty.
+//#define IMGUI_DISABLE_DEBUG_TOOLS                         // Disable metrics/debugger and other debug tools: ShowMetricsWindow(), ShowDebugLogWindow() and ShowIDStackToolWindow() will be empty.
 
 //---- Don't implement some functions to reduce linkage requirements.
 //#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)
 //#define IMGUI_ENABLE_WIN32_DEFAULT_IME_FUNCTIONS          // [Win32] [Default with Visual Studio] Implement default IME handler (require imm32.lib/.a, auto-link for Visual Studio, -limm32 on command-line for MinGW)
 //#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] [Default with non-Visual Studio compilers] Don't implement default IME handler (won't require imm32.lib/.a)
-//#define IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32 function (clipboard, ime).
+//#define IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32 function (clipboard, IME).
 //#define IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS      // [OSX] Implement default OSX clipboard handler (need to link with '-framework ApplicationServices', this is why this is not the default).
+//#define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS             // Don't implement default platform_io.Platform_OpenInShellFn() handler (Win32: ShellExecute(), require shell32.lib/.a, Mac/Linux: use system("")).
 //#define IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS            // Don't implement ImFormatString/ImFormatStringV so you can implement them yourself (e.g. if you don't want to link with vsnprintf)
 //#define IMGUI_DISABLE_DEFAULT_MATH_FUNCTIONS              // Don't implement ImFabs/ImSqrt/ImPow/ImFmod/ImCos/ImSin/ImAcos/ImAtan2 so you can implement them yourself.
 //#define IMGUI_DISABLE_FILE_FUNCTIONS                      // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle at all (replace them with dummies)
@@ -63,30 +66,46 @@
 //#define IMGUI_DISABLE_DEFAULT_ALLOCATORS                  // Don't implement default allocators calling malloc()/free() to avoid linking with them. You will need to call ImGui::SetAllocatorFunctions().
 //#define IMGUI_DISABLE_SSE                                 // Disable use of SSE intrinsics even if available
 
+//---- Enable Test Engine / Automation features.
+//#define IMGUI_ENABLE_TEST_ENGINE                          // Enable imgui_test_engine hooks. Generally set automatically by include "imgui_te_config.h", see Test Engine for details.
+
 //---- Include imgui_user.h at the end of imgui.h as a convenience
+// May be convenient for some users to only explicitly include vanilla imgui.h and have extra stuff included.
 //#define IMGUI_INCLUDE_IMGUI_USER_H
+//#define IMGUI_USER_H_FILENAME         "my_folder/my_imgui_user.h"
 
 //---- Pack colors to BGRA8 instead of RGBA8 (to avoid converting from one to another)
 //#define IMGUI_USE_BGRA_PACKED_COLOR
 
-//---- Use 32-bit for ImWchar (default is 16-bit) to support unicode planes 1-16. (e.g. point beyond 0xFFFF like emoticons, dingbats, symbols, shapes, ancient languages, etc...)
+//---- Use 32-bit for ImWchar (default is 16-bit) to support Unicode planes 1-16. (e.g. point beyond 0xFFFF like emoticons, dingbats, symbols, shapes, ancient languages, etc...)
 //#define IMGUI_USE_WCHAR32
 
 //---- Avoid multiple STB libraries implementations, or redefine path/filenames to prioritize another version
 // By default the embedded implementations are declared static and not available outside of Dear ImGui sources files.
 //#define IMGUI_STB_TRUETYPE_FILENAME   "my_folder/stb_truetype.h"
 //#define IMGUI_STB_RECT_PACK_FILENAME  "my_folder/stb_rect_pack.h"
+//#define IMGUI_STB_SPRINTF_FILENAME    "my_folder/stb_sprintf.h"    // only used if IMGUI_USE_STB_SPRINTF is defined.
 //#define IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
 //#define IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_SPRINTF_IMPLEMENTATION                   // only disabled if IMGUI_USE_STB_SPRINTF is defined.
 
-//---- Use stb_printf's faster implementation of vsnprintf instead of the one from libc (unless IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS is defined)
-// Requires 'stb_sprintf.h' to be available in the include path. Compatibility checks of arguments and formats done by clang and GCC will be disabled in order to support the extra formats provided by STB sprintf.
-// #define IMGUI_USE_STB_SPRINTF
+//---- Use stb_sprintf.h for a faster implementation of vsnprintf instead of the one from libc (unless IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS is defined)
+// Compatibility checks of arguments and formats done by clang and GCC will be disabled in order to support the extra formats provided by stb_sprintf.h.
+//#define IMGUI_USE_STB_SPRINTF
 
 //---- Use FreeType to build and rasterize the font atlas (instead of stb_truetype which is embedded by default in Dear ImGui)
 // Requires FreeType headers to be available in the include path. Requires program to be compiled with 'misc/freetype/imgui_freetype.cpp' (in this repository) + the FreeType library (not provided).
 // On Windows you may use vcpkg with 'vcpkg install freetype --triplet=x64-windows' + 'vcpkg integrate install'.
 //#define IMGUI_ENABLE_FREETYPE
+
+//---- Use FreeType + plutosvg or lunasvg to render OpenType SVG fonts (SVGinOT)
+// Only works in combination with IMGUI_ENABLE_FREETYPE.
+// - lunasvg is currently easier to acquire/install, as e.g. it is part of vcpkg.
+// - plutosvg will support more fonts and may load them faster. It currently requires to be built manually but it is fairly easy. See misc/freetype/README for instructions.
+// - Both require headers to be available in the include path + program to be linked with the library code (not provided).
+// - (note: lunasvg implementation is based on Freetype's rsvg-port.c which is licensed under CeCILL-C Free Software License Agreement)
+//#define IMGUI_ENABLE_FREETYPE_PLUTOSVG
+//#define IMGUI_ENABLE_FREETYPE_LUNASVG
 
 //---- Use stb_truetype to build and rasterize the font atlas (default)
 // The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.
@@ -95,14 +114,16 @@
 //---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
 // This will be inlined as part of ImVec2 and ImVec4 class declarations.
 /*
-#define IM_VEC2_CLASS_EXTRA                                                 \
-        ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                       \
+#define IM_VEC2_CLASS_EXTRA                                                     \
+        constexpr ImVec2(const MyVec2& f) : x(f.x), y(f.y) {}                   \
         operator MyVec2() const { return MyVec2(x,y); }
 
-#define IM_VEC4_CLASS_EXTRA                                                 \
-        ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; }     \
+#define IM_VEC4_CLASS_EXTRA                                                     \
+        constexpr ImVec4(const MyVec4& f) : x(f.x), y(f.y), z(f.z), w(f.w) {}   \
         operator MyVec4() const { return MyVec4(x,y,z,w); }
 */
+//---- ...Or use Dear ImGui's own very basic math operators.
+//#define IMGUI_DEFINE_MATH_OPERATORS
 
 //---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
@@ -116,23 +137,18 @@
 //typedef void (*MyImDrawCallback)(const ImDrawList* draw_list, const ImDrawCmd* cmd, void* my_renderer_user_data);
 //#define ImDrawCallback MyImDrawCallback
 
-//---- Debug Tools: Macro to break in Debugger
+//---- Debug Tools: Macro to break in Debugger (we provide a default implementation of this in the codebase)
 // (use 'Metrics->Tools->Item Picker' to pick widgets with the mouse and break into them for easy debugging.)
 //#define IM_DEBUG_BREAK  IM_ASSERT(0)
 //#define IM_DEBUG_BREAK  __debugbreak()
 
-//---- Debug Tools: Have the Item Picker break in the ItemAdd() function instead of ItemHoverable(),
-// (which comes earlier in the code, will catch a few extra items, allow picking items other than Hovered one.)
-// This adds a small runtime cost which is why it is not enabled by default.
-//#define IMGUI_DEBUG_TOOL_ITEM_PICKER_EX
-
 //---- Debug Tools: Enable slower asserts
 //#define IMGUI_DEBUG_PARANOID
 
-//---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
+//---- Tip: You can add extra functions within the ImGui:: namespace from anywhere (e.g. your own sources/header files)
 /*
 namespace ImGui
 {
-    void MyFunction(const char* name, const MyMatrix44& v);
+    void MyFunction(const char* name, MyMatrix44* mtx);
 }
 */

--- a/libimgui/manifest
+++ b/libimgui/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libimgui
-version: 1.91.0
+version: 1.91.4
 project: imgui
 summary: Dear ImGui: Bloat-free Graphical User interface for C++ with minimal dependencies
 license: MIT
@@ -12,8 +12,8 @@ src-url : https://github.com/ocornut/imgui
 package-url: https://github.com/build2-packaging/imgui
 package-email: swat.somebug@gmail.com
 
-depends: * build2 >= 0.15.0
-depends: * bpkg >= 0.15.0
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
 
 tests: libimgui-null-backend-test == $
 examples: libimgui-examples == $


### PR DESCRIPTION
Bump version to 1.91.4

[ocornut/imgui@v1.91.4 (release)](https://github.com/ocornut/imgui/releases/tag/v1.91.4)

https://ci.cppget.org/@0a431fd1-6252-4df5-a1c4-a34c0341c100